### PR TITLE
feat: Add test for client work page navigation

### DIFF
--- a/tests/epam-client-work.spec.ts
+++ b/tests/epam-client-work.spec.ts
@@ -1,0 +1,18 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('EPAM Website Navigation', () => {
+  test('should navigate to the Client Work page from the Services menu', async ({ page }) => {
+    // Step 1: Navigate to the website
+    await page.goto('https://www.epam.com/');
+
+    // Step 2: Select "Services" from the header menu
+    await page.getByRole('link', { name: 'Services' }).click();
+
+    // Step 3: Click the "Explore Our Client Work" link
+    await page.getByRole('link', { name: 'Explore Our Client Work' }).click();
+
+    // Step 4: Verify that the "Client Work" text is visible on the page
+    const clientWorkHeader = page.getByRole('heading', { name: 'Client Work' });
+    await expect(clientWorkHeader).toBeVisible();
+  });
+});


### PR DESCRIPTION
This pull request adds a new Playwright test for navigating to the Client Work page from the Services menu on the EPAM website.